### PR TITLE
fix(decideForKeys): Fixes response model for decideForKeys API.

### DIFF
--- a/lib/src/data_objects/decide_response.dart
+++ b/lib/src/data_objects/decide_response.dart
@@ -61,21 +61,20 @@ class Decision {
 }
 
 class BaseDecideResponse extends BaseResponse {
-  final List<Decision> _decisions = [];
+  final Map<String, Decision> _decisions = {};
 
   BaseDecideResponse(Map<String, dynamic> json) : super(json) {
     if (json[Constants.responseResult] is Map<dynamic, dynamic>) {
-      for (final value
-          in Map<String, dynamic>.from(json[Constants.responseResult]).values) {
-        if (value is Map<dynamic, dynamic>) {
-          var decision = Decision(Map<String, dynamic>.from(value));
-          _decisions.add(decision);
-        }
-      }
+      final decisionsMap =
+          Map<String, dynamic>.from(json[Constants.responseResult]);
+      decisionsMap.forEach((k, v) => {
+            if (v is Map<dynamic, dynamic>)
+              {_decisions[k] = Decision(Map<String, dynamic>.from(v))}
+          });
     }
   }
 
-  List<Decision> getDecisions() {
+  Map<String, Decision> getDecisions() {
     return _decisions;
   }
 }
@@ -86,13 +85,13 @@ class DecideResponse extends BaseDecideResponse {
   DecideResponse(Map<String, dynamic> json) : super(json) {
     final decisions = getDecisions();
     if (decisions.isNotEmpty) {
-      decision = decisions.first;
+      decision = decisions.values.first;
     }
   }
 }
 
 class DecideForKeysResponse extends BaseDecideResponse {
-  List<Decision> decisions = [];
+  Map<String, Decision> decisions = {};
 
   DecideForKeysResponse(Map<String, dynamic> json) : super(json) {
     decisions = getDecisions();

--- a/test/optimizely_flutter_sdk_test.dart
+++ b/test/optimizely_flutter_sdk_test.dart
@@ -234,7 +234,10 @@ void main() {
         expect(response.success, equals(true));
         expect(response.decision != null, equals(true));
         expect(response.reason, Constants.decideCalled);
-        expect(TestUtils.compareDecisions([response.decision!]), equals(true));
+        expect(
+            TestUtils.compareDecisions(
+                {response.decision!.flagKey: response.decision!}),
+            equals(true));
         expect(decideOptions.length == 5, equals(true));
         expect(assertDecideOptions(options, decideOptions), equals(true));
         decideOptions = [];

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -40,10 +40,9 @@ class TestUtils {
     Constants.flagKey: "feature_1"
   };
 
-  static bool compareDecisions(List<Decision> decisions) {
+  static bool compareDecisions(Map<String, Decision> decisions) {
     final correctDecision = Decision(decideResponseMap);
-    for (var i = 0; i < decisions.length; i++) {
-      final decision = decisions[i];
+    for (var decision in decisions.values) {
       if (decision.variationKey != correctDecision.variationKey) {
         return false;
       }


### PR DESCRIPTION
## Summary
- Fixes decideForKeys response model to contain map of decisions instead of array.

## Test plan
- All tests should pass.