### PR TITLE
Refac: Maintaining same output in android as it is from IOS

### DIFF
--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Constants.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Constants.java
@@ -87,10 +87,12 @@ public class Constants {
     }
 
     public static class ActivateListenerKeys {
-        public static final String EXPERIMENT_KEY = "experimentKey";
+        public static final String ID = "id";
+        public static final String KEY = "key";
+        public static final String EXPERIMENT = "experiment";
         public static final String USER_ID = "userId";
         public static final String ATTRIBUTES = "attributes";
-        public static final String VARIATION_KEY = "variationKey";
+        public static final String VARIATION = "variation";
     }
 
     public static class TrackListenerKeys {


### PR DESCRIPTION
## Summary
- Instead of returning true response with null variation key, now returning with success as false.
- Instead of returning always true from setForcedVariation now returning whatever the response status comes from android SDK.
- minor fixes in activate listener response. 


## Test plan
All tests should pass 