### PR TITLE
fix(OptimizelyConfig): fixing an crash for nil featureEnabled.

### DIFF
--- a/lib/src/data_objects/optimizely_config.dart
+++ b/lib/src/data_objects/optimizely_config.dart
@@ -320,10 +320,8 @@ class OptimizelyVariation {
   final Map<String, OptimizelyVariable> variablesMap;
 
   OptimizelyVariation(
-      {this.id,
-      this.key,
-      this.featureEnabled = false,
-      this.variablesMap = const {}});
+      {this.id, this.key, bool? featureEnabled, this.variablesMap = const {}})
+      : featureEnabled = featureEnabled ?? false;
 
   factory OptimizelyVariation.fromJson(Map<String, dynamic> parsedJson) {
     Map<String, OptimizelyVariable>? tempVariablesMap = {};

--- a/test_resources/OptimizelyConfig.json
+++ b/test_resources/OptimizelyConfig.json
@@ -94,7 +94,6 @@
               "off": {
                 "id": "35771",
                 "key": "off",
-                "featureEnabled": false,
                 "variablesMap": {}
               }
             }


### PR DESCRIPTION
## Summary
- Fixing an issue where nil `featureEnabled` inside `variation` caused sdk to crash when `getOptimizelyConfig` api was called.

## Test plan
- All unit and integration tests should pass.