### PR TITLE
Fix: Added proguard rules to resolve "no serializer found" error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,6 +49,9 @@ android {
         versionName version_name
         buildConfigField "String", "CLIENT_VERSION", "\"$version_name\""
         multiDexEnabled true
+
+        // these rules will be merged to app's proguard rules
+        consumerProguardFiles './proguard-rules.txt'
     }
 
     compileOptions {
@@ -61,7 +64,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/android/proguard-rules.txt
+++ b/android/proguard-rules.txt
@@ -1,0 +1,14 @@
+# Add project specific ProGuard rules here.
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Add any project specific keep options here:
+
+# Optimizely
+-keep class com.optimizely.optimizely_flutter_sdk.** {*;}
+-keep class com.fasterxml.jackson.** {*;}
+##---------------End: proguard configuration for Gson  ----------
+

--- a/android/proguard-rules.txt
+++ b/android/proguard-rules.txt
@@ -10,5 +10,5 @@
 # Optimizely
 -keep class com.optimizely.optimizely_flutter_sdk.** {*;}
 -keep class com.fasterxml.jackson.** {*;}
-##---------------End: proguard configuration for Gson  ----------
+##---------------End: proguard configuration ----------
 


### PR DESCRIPTION
## Summary
- "no serializer found" error is resolved by adding proguard rules. 


## Test plan
All tests should pass. 

## Issues
- "THING-1234" or "Fixes #123"