### PR TITLE
[FSSDK-9430] feat: add configurable log level support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.0'
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
     //implementation group: 'org.slf4j', name: 'slf4j-android', version: '1.7.25'
-    //implementation 'org.slf4j:slf4j-api:2.0.7'
+    implementation 'org.slf4j:slf4j-api:2.0.7'
     implementation 'com.github.tony19:logback-android:3.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10"
     implementation "com.optimizely.ab:android-sdk:4.0.0-beta2"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,11 +76,12 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.0'
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
 
-    //"logback-android" required for programmatic control of glbal sl4j log level
-    // [ref] https://github.com/tony19/logback-android
+    //"logback-android" required for programmatic control of glbal sl4j log level.
+    // - default log configuration in /assets/logback.xml
+    // - [ref] https://github.com/tony19/logback-android
     implementation 'com.github.tony19:logback-android:3.0.0'
     implementation 'org.slf4j:slf4j-api:2.0.7'
-    
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10"
     implementation "com.optimizely.ab:android-sdk:4.0.0-beta2"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.0'
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
 
-    //"logback-android" required for programmatic control of glbal sl4j log level.
+    //"logback-android" required for programmatic control of global sl4j log level.
     // - default log configuration in /assets/logback.xml
     // - [ref] https://github.com/tony19/logback-android
     implementation 'com.github.tony19:logback-android:3.0.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,9 @@ android {
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.0'
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
-    implementation group: 'org.slf4j', name: 'slf4j-android', version: '1.7.25'
+    //implementation group: 'org.slf4j', name: 'slf4j-android', version: '1.7.25'
+    //implementation 'org.slf4j:slf4j-api:2.0.7'
+    implementation 'com.github.tony19:logback-android:3.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10"
     implementation "com.optimizely.ab:android-sdk:4.0.0-beta2"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,9 +75,12 @@ android {
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.0'
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
-    //implementation group: 'org.slf4j', name: 'slf4j-android', version: '1.7.25'
-    implementation 'org.slf4j:slf4j-api:2.0.7'
+
+    //"logback-android" required for programmatic control of glbal sl4j log level
+    // [ref] https://github.com/tony19/logback-android
     implementation 'com.github.tony19:logback-android:3.0.0'
+    implementation 'org.slf4j:slf4j-api:2.0.7'
+    
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10"
     implementation "com.optimizely.ab:android-sdk:4.0.0-beta2"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10"
     implementation "com.optimizely.ab:android-sdk:4.0.0-beta2"
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
     implementation ('com.google.guava:guava:19.0') {
         exclude group:'com.google.guava', module:'listenablefuture'
     }

--- a/android/src/main/assets/logback.xml
+++ b/android/src/main/assets/logback.xml
@@ -1,0 +1,18 @@
+<configuration
+    xmlns="https://tony19.github.io/logback-android/xml"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://tony19.github.io/logback-android/xml https://cdn.jsdelivr.net/gh/tony19/logback-android/logback.xsd"
+>
+    <appender name="logcat" class="ch.qos.logback.classic.android.LogcatAppender">
+        <tagEncoder>
+            <pattern>Optimizely</pattern>
+        </tagEncoder>
+        <encoder>
+            <pattern>%msg</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="logcat" />
+    </root>
+</configuration>

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/OptimizelyFlutterClient.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/OptimizelyFlutterClient.java
@@ -97,6 +97,10 @@ public class OptimizelyFlutterClient {
             maxQueueSize = argumentsParser.getEventMaxQueueSize();
         }
 
+        if (argumentsParser.getDefaultLogLevel() != null) {
+            Utils.setDefaultLogLevel(argumentsParser.getDefaultLogLevel());
+        }
+
         DefaultEventHandler eventHandler = DefaultEventHandler.getInstance(context);
         eventHandler.setDispatchInterval(-1L);
         NotificationCenter notificationCenter = new NotificationCenter();

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/OptimizelyFlutterClient.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/OptimizelyFlutterClient.java
@@ -97,9 +97,7 @@ public class OptimizelyFlutterClient {
             maxQueueSize = argumentsParser.getEventMaxQueueSize();
         }
 
-        if (argumentsParser.getDefaultLogLevel() != null) {
-            Utils.setDefaultLogLevel(argumentsParser.getDefaultLogLevel());
-        }
+        Utils.setDefaultLogLevel(argumentsParser.getDefaultLogLevel());
 
         DefaultEventHandler eventHandler = DefaultEventHandler.getInstance(context);
         eventHandler.setDispatchInterval(-1L);

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/ArgumentsParser.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/ArgumentsParser.java
@@ -72,6 +72,10 @@ public class ArgumentsParser {
         return Utils.getDecideOptions((List<String>) arguments.get(Constants.RequestParameterKey.DECIDE_OPTIONS));
     }
 
+    public String getDefaultLogLevel() {
+        return (String) arguments.get(Constants.RequestParameterKey.DEFAULT_LOG_LEVEL);
+    }
+
     public String getFlagKey() {
         return (String) arguments.get(Constants.RequestParameterKey.FLAG_KEY);
     }

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Constants.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Constants.java
@@ -67,6 +67,7 @@ public class Constants {
         public static final String ATTRIBUTES = "attributes";
         public static final String DECIDE_KEYS = "keys";
         public static final String DECIDE_OPTIONS = "optimizelyDecideOption";
+        public static final String DEFAULT_LOG_LEVEL = "defaultLogLevel";
         public static final String EVENT_BATCH_SIZE = "eventBatchSize";
         public static final String EVENT_TIME_INTERVAL = "eventTimeInterval";
         public static final String EVENT_MAX_QUEUE_SIZE = "eventMaxQueueSize";
@@ -152,5 +153,12 @@ public class Constants {
     public static class SegmentOption {
         public static final String IGNORE_CACHE = "ignoreCache";
         public static final String RESET_CACHE = "resetCache";
+    }
+
+    public static class LogLevel {
+        public static final String ERROR = "error";
+        public static final String WARNING = "warning";
+        public static final String INFO = "info";
+        public static final String DEBUG = "debug";
     }
 }

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Utils.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Utils.java
@@ -108,6 +108,16 @@ public class Utils {
         return listenerClass;
     }
 
+    // SLF4J log level control:
+    // - logback logger (ch.qos.logback) is the only option that supports global log level control programmatically (not only via configuration file)
+    // - "logback-android" logger (com.github.tony19:logback-android) is integrated in build.gradle.
+
+    public static void setDefaultLogLevel(String logLevel) {
+        Level defaultLogLevel = Utils.mapLogLevel(logLevel);
+        Logger rootLogger = (Logger) LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+        rootLogger.setLevel(defaultLogLevel);
+    }
+
     public static Level mapLogLevel(String logLevel) {
         Level level = Level.INFO;
 
@@ -123,11 +133,6 @@ public class Utils {
             default: {}
         }
         return level;
-    }
-
-    public static void setDefaultLogLevel(String logLevel) {
-        Logger rootLogger = (Logger) LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
-        rootLogger.setLevel(Utils.mapLogLevel(logLevel));
     }
 
 }

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Utils.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Utils.java
@@ -31,6 +31,9 @@ import com.optimizely.ab.notification.TrackNotification;
 import com.optimizely.ab.notification.UpdateConfigNotification;
 import com.optimizely.ab.odp.ODPSegmentOption;
 import com.optimizely.ab.optimizelydecision.OptimizelyDecideOption;
+import org.slf4j.LoggerFactory;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 
 public class Utils {
 
@@ -104,4 +107,27 @@ public class Utils {
         }
         return listenerClass;
     }
+
+    public static Level mapLogLevel(String logLevel) {
+        Level level = Level.INFO;
+
+        if (logLevel == null || logLevel.isEmpty()) {
+            return level;
+        }
+
+        switch (logLevel) {
+            case Constants.LogLevel.ERROR: level = Level.ERROR; break;
+            case Constants.LogLevel.WARNING: level = Level.WARN; break;
+            case Constants.LogLevel.INFO: level = Level.INFO; break;
+            case Constants.LogLevel.DEBUG: level = Level.DEBUG; break;
+            default: {}
+        }
+        return level;
+    }
+
+    public static void setDefaultLogLevel(String logLevel) {
+        Logger rootLogger = (Logger) LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+        rootLogger.setLevel(Utils.mapLogLevel(logLevel));
+    }
+
 }

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Utils.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Utils.java
@@ -109,8 +109,9 @@ public class Utils {
     }
 
     // SLF4J log level control:
-    // - logback logger (ch.qos.logback) is the only option that supports global log level control programmatically (not only via configuration file)
+    // - logback logger (ch.qos.logback) is the only option available that supports global log level control programmatically (not only via configuration file)
     // - "logback-android" logger (com.github.tony19:logback-android) is integrated in build.gradle.
+    // - log-level control is not integrated into the native android-sdk core since this solution depends on logback logger.
 
     public static void setDefaultLogLevel(String logLevel) {
         Level defaultLogLevel = Utils.mapLogLevel(logLevel);

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Utils.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Utils.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import androidx.annotation.Nullable;
 
 import static com.optimizely.ab.notification.DecisionNotification.FeatureVariableDecisionNotificationBuilder.SOURCE_INFO;
 
@@ -113,13 +114,13 @@ public class Utils {
     // - "logback-android" logger (com.github.tony19:logback-android) is integrated in build.gradle.
     // - log-level control is not integrated into the native android-sdk core since this solution depends on logback logger.
 
-    public static void setDefaultLogLevel(String logLevel) {
+    public static void setDefaultLogLevel(@Nullable String logLevel) {
         Level defaultLogLevel = Utils.mapLogLevel(logLevel);
         Logger rootLogger = (Logger) LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
         rootLogger.setLevel(defaultLogLevel);
     }
 
-    public static Level mapLogLevel(String logLevel) {
+    public static Level mapLogLevel(@Nullable String logLevel) {
         Level level = Level.INFO;
 
         if (logLevel == null || logLevel.isEmpty()) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 32
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -40,7 +40,7 @@ android {
         // You can update the following values to match your application needs. 
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion 21
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 32
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,6 +32,7 @@ class _MyAppState extends State<MyApp> {
         datafilePeriodicDownloadInterval: 10 * 60,
         eventOptions: const EventOptions(
             batchSize: 1, timeInterval: 60, maxQueueSize: 10000),
+        defaultLogLevel: OptimizelyLogLevel.debug,
         defaultDecideOptions: defaultOptions);
     var response = await flutterSDK.initializeClient();
 

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		90B9B075FD9D5B075E83BE96 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A8DB69DD1CEB9DE6D5A4070 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,9 +53,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		019D04A8C81D7599D2E638FA /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* optimizely_flutter_sdk_example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "optimizely_flutter_sdk_example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* optimizely_flutter_sdk_example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = optimizely_flutter_sdk_example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -66,7 +68,10 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		5A8DB69DD1CEB9DE6D5A4070 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		7EEA78DE428A25C4C9195EC6 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		8D05B77804EBF39FD6D6D079 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -75,6 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90B9B075FD9D5B075E83BE96 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -99,6 +105,7 @@
 				33CEB47122A05771004F2AC0 /* Flutter */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				F74646C1D5F338EF32BE10E1 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -148,8 +155,20 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5A8DB69DD1CEB9DE6D5A4070 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F74646C1D5F338EF32BE10E1 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				7EEA78DE428A25C4C9195EC6 /* Pods-Runner.debug.xcconfig */,
+				8D05B77804EBF39FD6D6D079 /* Pods-Runner.release.xcconfig */,
+				019D04A8C81D7599D2E638FA /* Pods-Runner.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -159,11 +178,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				834CC0346DE4E8E368DFDFD4 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				F96AA93D7120056FD027BD50 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -269,6 +290,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		834CC0346DE4E8E368DFDFD4 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F96AA93D7120056FD027BD50 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/example/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/example/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/ios/Classes/HelperClasses/Constants.swift
+++ b/ios/Classes/HelperClasses/Constants.swift
@@ -90,6 +90,7 @@ struct RequestParameterKey {
     static let eventTags = "eventTags"
     static let reasons = "reasons"
     static let decideOptions = "optimizelyDecideOption"
+    static let defaultLogLevel = "defaultLogLevel"
     static let eventBatchSize = "eventBatchSize"
     static let eventTimeInterval = "eventTimeInterval"
     static let eventMaxQueueSize = "eventMaxQueueSize"

--- a/ios/Classes/HelperClasses/Utils.swift
+++ b/ios/Classes/HelperClasses/Utils.swift
@@ -202,4 +202,17 @@ public class Utils: NSObject {
             return nil
         }
     }
+
+    static func getDefaultLogLevel(_ logLevel: String) -> OptimizelyLogLevel {
+        var defaultLogLevel: OptimizelyLogLevel
+        switch logLevel {
+            case "error": defaultLogLevel = OptimizelyLogLevel.error
+            case "warning": defaultLogLevel = OptimizelyLogLevel.warning
+            case "info": defaultLogLevel = OptimizelyLogLevel.info
+            case "debug": defaultLogLevel = OptimizelyLogLevel.debug
+            default: defaultLogLevel = OptimizelyLogLevel.info
+        }
+        return defaultLogLevel;
+    }
+
 }

--- a/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
@@ -81,6 +81,10 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
     
     /// Initializes optimizely client with the provided sdkKey
     func initialize(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+
+        print("[iOS][flutter] initialize")
+
+
         guard let (parameters, sdkKey) = getParametersAndSdkKey(arguments: call.arguments, result: result) else {
             return
         }
@@ -106,7 +110,13 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
             decideOptions = options
         }
         let defaultDecideOptions = Utils.getDecideOptions(options: decideOptions)
-        
+
+        var defaultLogLevel = OptimizelyLogLevel.info
+        if let logLevel = parameters[RequestParameterKey.defaultLogLevel] as? String {
+            defaultLogLevel = Utils.getDefaultLogLevel(logLevel)
+        }
+        print("[iOS][flutter] \(parameters[RequestParameterKey.defaultLogLevel]) -> \(defaultLogLevel)")
+
         // SDK Settings Default Values
         var segmentsCacheSize: Int = 100
         var segmentsCacheTimeoutInSecs: Int = 600
@@ -152,7 +162,14 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
         optimizelyClientsTracker.removeValue(forKey: sdkKey)
         
         // Creating new instance
-        let optimizelyInstance = OptimizelyClient(sdkKey:sdkKey, eventDispatcher: eventDispatcher, datafileHandler: datafileHandler, periodicDownloadInterval: datafilePeriodicDownloadInterval, defaultDecideOptions: defaultDecideOptions, settings: optimizelySdkSettings)
+        let optimizelyInstance = OptimizelyClient(
+            sdkKey:sdkKey, 
+            eventDispatcher: eventDispatcher, 
+            datafileHandler: datafileHandler, 
+            periodicDownloadInterval: datafilePeriodicDownloadInterval, 
+    ///        defaultLogLevel: defaultLogLevel,
+            defaultDecideOptions: defaultDecideOptions, 
+            settings: optimizelySdkSettings)
         
         optimizelyInstance.start{ [weak self] res in
             switch res {

--- a/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
@@ -81,10 +81,6 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
     
     /// Initializes optimizely client with the provided sdkKey
     func initialize(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-
-        print("[iOS][flutter] initialize")
-
-
         guard let (parameters, sdkKey) = getParametersAndSdkKey(arguments: call.arguments, result: result) else {
             return
         }
@@ -115,7 +111,6 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
         if let logLevel = parameters[RequestParameterKey.defaultLogLevel] as? String {
             defaultLogLevel = Utils.getDefaultLogLevel(logLevel)
         }
-        print("[iOS][flutter] \(parameters[RequestParameterKey.defaultLogLevel]) -> \(defaultLogLevel)")
 
         // SDK Settings Default Values
         var segmentsCacheSize: Int = 100
@@ -167,7 +162,7 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
             eventDispatcher: eventDispatcher, 
             datafileHandler: datafileHandler, 
             periodicDownloadInterval: datafilePeriodicDownloadInterval, 
-    ///        defaultLogLevel: defaultLogLevel,
+            defaultLogLevel: defaultLogLevel,
             defaultDecideOptions: defaultDecideOptions, 
             settings: optimizelySdkSettings)
         

--- a/lib/optimizely_flutter_sdk.dart
+++ b/lib/optimizely_flutter_sdk.dart
@@ -28,6 +28,8 @@ import 'package:optimizely_flutter_sdk/src/data_objects/optimizely_config_respon
 import 'package:optimizely_flutter_sdk/src/optimizely_client_wrapper.dart';
 import 'package:optimizely_flutter_sdk/src/user_context/optimizely_user_context.dart';
 
+import 'src/data_objects/log_levels.dart';
+
 export 'package:optimizely_flutter_sdk/src/optimizely_client_wrapper.dart'
     show ClientPlatform, ListenerType;
 export 'package:optimizely_flutter_sdk/src/user_context/optimizely_forced_decision.dart'
@@ -50,6 +52,8 @@ export 'package:optimizely_flutter_sdk/src/data_objects/sdk_settings.dart'
     show SDKSettings;
 export 'package:optimizely_flutter_sdk/src/data_objects/datafile_options.dart'
     show DatafileHostOptions;
+export 'package:optimizely_flutter_sdk/src/data_objects/log_levels.dart'
+    show OptimizelyLogLevel;
 
 /// The main client class for the Optimizely Flutter SDK.
 ///
@@ -63,6 +67,7 @@ class OptimizelyFlutterSdk {
   final int _datafilePeriodicDownloadInterval;
   final Map<ClientPlatform, DatafileHostOptions> _datafileHostOptions;
   final Set<OptimizelyDecideOption> _defaultDecideOptions;
+  final OptimizelyLogLevel _defaultLogLevel;
   final SDKSettings _sdkSettings;
   OptimizelyFlutterSdk(this._sdkKey,
       {EventOptions eventOptions = const EventOptions(),
@@ -70,11 +75,13 @@ class OptimizelyFlutterSdk {
           10 * 60, // Default time interval in seconds
       Map<ClientPlatform, DatafileHostOptions> datafileHostOptions = const {},
       Set<OptimizelyDecideOption> defaultDecideOptions = const {},
+      OptimizelyLogLevel defaultLogLevel = OptimizelyLogLevel.info,
       SDKSettings sdkSettings = const SDKSettings()})
       : _eventOptions = eventOptions,
         _datafilePeriodicDownloadInterval = datafilePeriodicDownloadInterval,
         _datafileHostOptions = datafileHostOptions,
         _defaultDecideOptions = defaultDecideOptions,
+        _defaultLogLevel = defaultLogLevel,
         _sdkSettings = sdkSettings;
 
   /// Starts Optimizely SDK (Synchronous) with provided sdkKey.
@@ -85,6 +92,7 @@ class OptimizelyFlutterSdk {
         _datafilePeriodicDownloadInterval,
         _datafileHostOptions,
         _defaultDecideOptions,
+        _defaultLogLevel,
         _sdkSettings);
   }
 

--- a/lib/optimizely_flutter_sdk.dart
+++ b/lib/optimizely_flutter_sdk.dart
@@ -27,8 +27,7 @@ import 'package:optimizely_flutter_sdk/src/data_objects/get_variation_response.d
 import 'package:optimizely_flutter_sdk/src/data_objects/optimizely_config_response.dart';
 import 'package:optimizely_flutter_sdk/src/optimizely_client_wrapper.dart';
 import 'package:optimizely_flutter_sdk/src/user_context/optimizely_user_context.dart';
-
-import 'src/data_objects/log_levels.dart';
+import 'package:optimizely_flutter_sdk/src/data_objects/log_level.dart';
 
 export 'package:optimizely_flutter_sdk/src/optimizely_client_wrapper.dart'
     show ClientPlatform, ListenerType;
@@ -52,7 +51,7 @@ export 'package:optimizely_flutter_sdk/src/data_objects/sdk_settings.dart'
     show SDKSettings;
 export 'package:optimizely_flutter_sdk/src/data_objects/datafile_options.dart'
     show DatafileHostOptions;
-export 'package:optimizely_flutter_sdk/src/data_objects/log_levels.dart'
+export 'package:optimizely_flutter_sdk/src/data_objects/log_level.dart'
     show OptimizelyLogLevel;
 
 /// The main client class for the Optimizely Flutter SDK.

--- a/lib/src/data_objects/log_level.dart
+++ b/lib/src/data_objects/log_level.dart
@@ -1,0 +1,22 @@
+/// **************************************************************************
+/// Copyright 2023, Optimizely, Inc. and contributors                        *
+///                                                                          *
+/// Licensed under the Apache License, Version 2.0 (the "License");          *
+/// you may not use this file except in compliance with the License.         *
+/// You may obtain a copy of the License at                                  *
+///                                                                          *
+///    http://www.apache.org/licenses/LICENSE-2.0                            *
+///                                                                          *
+/// Unless required by applicable law or agreed to in writing, software      *
+/// distributed under the License is distributed on an "AS IS" BASIS,        *
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+/// See the License for the specific language governing permissions and      *
+/// limitations under the License.                                           *
+///**************************************************************************/
+
+enum OptimizelyLogLevel {
+  error,
+  warning,
+  info,
+  debug
+}

--- a/lib/src/data_objects/log_levels.dart
+++ b/lib/src/data_objects/log_levels.dart
@@ -1,7 +1,0 @@
-/// Log levels for the SDK.
-enum OptimizelyLogLevel {
-  error,
-  warning,
-  info,
-  debug
-}

--- a/lib/src/data_objects/log_levels.dart
+++ b/lib/src/data_objects/log_levels.dart
@@ -1,0 +1,7 @@
+/// Log levels for the SDK.
+enum OptimizelyLogLevel {
+  error,
+  warning,
+  info,
+  debug
+}

--- a/lib/src/optimizely_client_wrapper.dart
+++ b/lib/src/optimizely_client_wrapper.dart
@@ -67,12 +67,13 @@ class OptimizelyClientWrapper {
       SDKSettings sdkSettings) async {
     _channel.setMethodCallHandler(methodCallHandler);
     final convertedOptions = Utils.convertDecideOptions(defaultDecideOptions);
+    final convertedLogLevel = Utils.convertLogLevel(defaultLogLevel);
     Map<String, dynamic> requestDict = {
       Constants.sdkKey: sdkKey,
       Constants.datafilePeriodicDownloadInterval:
           datafilePeriodicDownloadInterval,
       Constants.optimizelyDecideOption: convertedOptions,
-      Constants.defaultLogLevel: defaultLogLevel.toString().split('.').last,   // "error", "warning", "info", "debug"
+      Constants.defaultLogLevel: convertedLogLevel,
       Constants.eventBatchSize: eventOptions.batchSize,
       Constants.eventTimeInterval: eventOptions.timeInterval,
       Constants.eventMaxQueueSize: eventOptions.maxQueueSize,

--- a/lib/src/optimizely_client_wrapper.dart
+++ b/lib/src/optimizely_client_wrapper.dart
@@ -27,6 +27,8 @@ import 'package:optimizely_flutter_sdk/src/data_objects/optimizely_config_respon
 import 'package:optimizely_flutter_sdk/src/utils/constants.dart';
 import 'package:optimizely_flutter_sdk/src/utils/utils.dart';
 
+import 'data_objects/log_levels.dart';
+
 enum ListenerType { activate, track, decision, logEvent, projectConfigUpdate }
 
 enum ClientPlatform { iOS, android }
@@ -61,6 +63,7 @@ class OptimizelyClientWrapper {
       int datafilePeriodicDownloadInterval,
       Map<ClientPlatform, DatafileHostOptions> datafileHostOptions,
       Set<OptimizelyDecideOption> defaultDecideOptions,
+      OptimizelyLogLevel defaultLogLevel,
       SDKSettings sdkSettings) async {
     _channel.setMethodCallHandler(methodCallHandler);
     final convertedOptions = Utils.convertDecideOptions(defaultDecideOptions);
@@ -69,6 +72,7 @@ class OptimizelyClientWrapper {
       Constants.datafilePeriodicDownloadInterval:
           datafilePeriodicDownloadInterval,
       Constants.optimizelyDecideOption: convertedOptions,
+      Constants.defaultLogLevel: defaultLogLevel.toString(),
       Constants.eventBatchSize: eventOptions.batchSize,
       Constants.eventTimeInterval: eventOptions.timeInterval,
       Constants.eventMaxQueueSize: eventOptions.maxQueueSize,

--- a/lib/src/optimizely_client_wrapper.dart
+++ b/lib/src/optimizely_client_wrapper.dart
@@ -72,7 +72,7 @@ class OptimizelyClientWrapper {
       Constants.datafilePeriodicDownloadInterval:
           datafilePeriodicDownloadInterval,
       Constants.optimizelyDecideOption: convertedOptions,
-      Constants.defaultLogLevel: defaultLogLevel.toString(),
+      Constants.defaultLogLevel: defaultLogLevel.toString().split('.').last,   // "error", "warning", "info", "debug"
       Constants.eventBatchSize: eventOptions.batchSize,
       Constants.eventTimeInterval: eventOptions.timeInterval,
       Constants.eventMaxQueueSize: eventOptions.maxQueueSize,

--- a/lib/src/optimizely_client_wrapper.dart
+++ b/lib/src/optimizely_client_wrapper.dart
@@ -27,7 +27,7 @@ import 'package:optimizely_flutter_sdk/src/data_objects/optimizely_config_respon
 import 'package:optimizely_flutter_sdk/src/utils/constants.dart';
 import 'package:optimizely_flutter_sdk/src/utils/utils.dart';
 
-import 'data_objects/log_levels.dart';
+import 'data_objects/log_level.dart';
 
 enum ListenerType { activate, track, decision, logEvent, projectConfigUpdate }
 

--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -83,6 +83,7 @@ class Constants {
   static const String optimizelyDecideOption = "optimizelyDecideOption";
   static const String optimizelySegmentOption = "optimizelySegmentOption";
   static const String optimizelySdkSettings = "optimizelySdkSettings";
+  static const String defaultLogLevel = "defaultLogLevel";
   static const String payload = "payload";
   static const String value = "value";
   static const String type = "type";

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -18,6 +18,7 @@ import 'dart:io' show Platform;
 
 import 'package:optimizely_flutter_sdk/src/user_context/optimizely_user_context.dart';
 import 'package:optimizely_flutter_sdk/src/utils/constants.dart';
+import 'package:optimizely_flutter_sdk/src/data_objects/log_level.dart';
 
 class Utils {
   static Map<OptimizelyDecideOption, String> decideOptions = {
@@ -93,5 +94,11 @@ class Utils {
   static List<String> convertSegmentOptions(
       Set<OptimizelySegmentOption> options) {
     return options.map((option) => Utils.segmentOptions[option]!).toList();
+  }
+
+  static String convertLogLevel(OptimizelyLogLevel logLevel) {
+    // OptimizelyLogLevel.error -> "error"
+    // OptimizelyLogLevel.debug -> "debug"
+    return logLevel.toString().split('.').last;  
   }
 }

--- a/test/optimizely_flutter_sdk_test.dart
+++ b/test/optimizely_flutter_sdk_test.dart
@@ -56,6 +56,7 @@ void main() {
   DatafileHostOptions datafileHostOptions = const DatafileHostOptions("", "");
   SDKSettings sdkSettings = const SDKSettings();
   int datafilePeriodicDownloadInterval = 0;
+  String defaultLogLevel = "error";
 
   const MethodChannel channel = MethodChannel("optimizely_flutter_sdk");
   dynamic mockOptimizelyConfig;
@@ -83,6 +84,9 @@ void main() {
         case Constants.initializeMethod:
           expect(methodCall.arguments[Constants.sdkKey], isNotEmpty);
           expect(methodCall.arguments[Constants.userContextId], isNull);
+
+          defaultLogLevel = methodCall.arguments[Constants.defaultLogLevel];
+
           // To Check if eventOptions were received
           eventOptions = EventOptions(
               batchSize: methodCall.arguments[Constants.eventBatchSize],
@@ -539,6 +543,33 @@ void main() {
         expect(datafileHostOptions.datafileHostSuffix,
             equals(expectedDatafileHostOptions.datafileHostSuffix));
         debugDefaultTargetPlatformOverride = null;
+      });
+    });
+
+    group("log level", () {
+      test("with no defaultLogLevel, log level should be info level", () async {
+        var sdk = OptimizelyFlutterSdk(testSDKKey);
+
+        var response = await sdk.initializeClient();
+
+        expect(response.success, isTrue);
+        expect(defaultLogLevel, equals("info"));
+      });
+
+      test("with a valid defaultLogLevel parameter", () async {
+        var sdk = OptimizelyFlutterSdk(testSDKKey, defaultLogLevel: OptimizelyLogLevel.debug);
+
+        var response = await sdk.initializeClient();
+
+        expect(response.success, isTrue);
+        expect(defaultLogLevel, equals("debug"));
+      });
+
+      test("should convert OptimizelyLogLevel to string", () async {
+        expect(Utils.convertLogLevel(OptimizelyLogLevel.error), "error");
+        expect(Utils.convertLogLevel(OptimizelyLogLevel.warning), "warning");
+        expect(Utils.convertLogLevel(OptimizelyLogLevel.info), "info");
+        expect(Utils.convertLogLevel(OptimizelyLogLevel.debug), "debug");
       });
     });
 

--- a/test/optimizely_flutter_sdk_test.dart
+++ b/test/optimizely_flutter_sdk_test.dart
@@ -546,7 +546,7 @@ void main() {
       });
     });
 
-    group("log level", () {
+    group("log level configuration", () {
       test("with no defaultLogLevel, log level should be info level", () async {
         var sdk = OptimizelyFlutterSdk(testSDKKey);
 


### PR DESCRIPTION
## Summary
Clients can control default log-level of native swift-sdk and android-sdk with a parameter value when initializing SDK.

- swift-adk already supports configurable log-level. 
- android-sdk does not support configurable log-level programmatically. A global slf4j log-level control added into the android plugin wrapper.

Example: `OptimizelyFlutterSDK(defaultLogLevel: OptimizelyLogLevel.debug)`

## Test plan
- add unit tests validating dart log-level propagated to native swift and android-sdk log-level control.

## Issues
- FSSDK-9430
- FSSDK-9468