### PR TITLE
[FSSDK-9493] Fix: FetchQualifiedSegments without options, crash fixed

### DIFF
--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Utils.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/helper_classes/Utils.java
@@ -68,7 +68,7 @@ public class Utils {
     }
 
     public static List<ODPSegmentOption> getSegmentOptions(List<String> options) {
-        if(options == null || options.isEmpty()) {
+        if(options == null) {
             return null;
         }
         List<ODPSegmentOption> convertedOptions = new ArrayList<>();


### PR DESCRIPTION
## Summary
- Fix the crush issue for android `fetchQualifiedSegments` API when no options provided.

## Test plan
-  All previous tests should pass

## Issues
- FSSDK-9493