### PR TITLE
[FSSDK-9592] fix proguard for logback and dart version

### DIFF
--- a/android/proguard-rules.txt
+++ b/android/proguard-rules.txt
@@ -10,5 +10,6 @@
 # Optimizely
 -keep class com.optimizely.optimizely_flutter_sdk.** {*;}
 -keep class com.fasterxml.jackson.** {*;}
+# Logback
+-keep class ch.qos.** { *; }
 ##---------------End: proguard configuration ----------
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.0-beta
 homepage: https://github.com/optimizely/optimizely-flutter-sdk
 
 environment:
-  sdk: '>=2.16.2 <=3.1.2'
+  sdk: '>=2.16.2 <4.0.0'
   flutter: ">=2.5.0"
 
 dependencies:


### PR DESCRIPTION
## Summary
- add proguard rule for logback (crashes in release mode)
- change the dart version requirements to 4.0

These fixes are not directly related to FSSDK-9582. Issues found while working on the ticket.

## Test plan
- Manual testing with release build (validate obfuscating)

## Issues
- [FSSDK-9592](https://jira.sso.episerver.net/browse/FSSDK-9592)