### PR TITLE
[FSSDK-9900] chore: Update read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See the [pubspec.yaml](https://github.com/optimizely/optimizely-flutter-sdk/blob
 
 On the Android platform, the SDK requires a minimum SDK version of 21 or higher and compile SDK version of 32.
 
-On the iOS platform, the SDK requires a minimum version of 10.0.
+On the iOS platform, the SDK requires a minimum version of 11.0.
 
 Other Flutter platforms are not currently supported by this SDK.
 


### PR DESCRIPTION
## Summary
- From Flutter 1.0.0, minimum requirement is iOS 11.0

## Test plan
N/A

## Issues
- [FSSDK-9900](https://jira.sso.episerver.net/browse/FSSDK-9900)