### PR TITLE
fix: resolve proguard configuration issues

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,8 +59,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled true 
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt', 'proguard-rules.pro'
         }
     }
 

--- a/android/proguard-rules.txt
+++ b/android/proguard-rules.txt
@@ -8,8 +8,28 @@
 # Add any project specific keep options here:
 
 # Optimizely
--keep class com.optimizely.optimizely_flutter_sdk.** {*;}
--keep class com.fasterxml.jackson.** {*;}
-# Logback
--keep class ch.qos.** { *; }
+-keep class com.optimizely.optimizely_flutter_sdk.OptimizelyFlutterSdkPlugin { *; }
+-keep class com.optimizely.optimizely_flutter_sdk.** { *; }
+-keep class com.optimizely.ab.** { *; }
+
+# Keep Jackson classes for JSON parsing
+-keep class com.fasterxml.jackson.** { *; }
+-dontwarn com.fasterxml.jackson.**
+
+# Keep Guava classes
+-keep class com.google.common.** { *; }
+-dontwarn com.google.common.**
+-dontwarn com.google.android.play.core.**
+
+# Keep SLF4J and Logback classes
+-keep class org.slf4j.** { *; }
+-keep class ch.qos.logback.** { *; }
+-dontwarn org.slf4j.**
+-dontwarn ch.qos.logback.**
+
+# Missing Dependencies (Android doesn't have these)
+-dontwarn javax.mail.**
+-dontwarn javax.activation.**
+-dontwarn javax.servlet.**
+
 ##---------------End: proguard configuration ----------

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -50,6 +50,8 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+            minifyEnabled true
+            shrinkResources false
         }
     }
 }
@@ -59,5 +61,5 @@ flutter {
 }
 
 dependencies {
-    implementation 'com.android.support:multidex:1.0.3'
+    implementation 'com.android.support:multidex:2.0.0'
 }


### PR DESCRIPTION
- Update proguard configuration in build.gradle
- Add missing dependencies for ProGuard rules
- Update Android multidex support version in dependencies in app/build.gradle

## Summary
- The "what"; a concise description of each logical change
- Another change

The "why", or other context.

## Test plan

## Issues
- "THING-1234" or "Fixes #123"