### PR TITLE
Prep for release 3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Optimizely Flutter SDK Changelog
 
+## 3.4.2
+March 25, 2026
+
+### Bug Fixes
+* Ensure FlutterResult and invokeMethod are always called on main thread ([#98](https://github.com/optimizely/optimizely-flutter-sdk/pull/98))
+
 ## 3.4.1
 January 28th, 2026
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Other Flutter platforms are not currently supported by this SDK.
 To add the flutter-sdk to your project dependencies, include the following in your app's pubspec.yaml:
 
 ```
-   optimizely_flutter_sdk: ^3.4.1
+   optimizely_flutter_sdk: ^3.4.2
 ```
 
 Then run 

--- a/lib/package_info.dart
+++ b/lib/package_info.dart
@@ -3,5 +3,5 @@
 
 class PackageInfo {
   static const String name = 'optimizely_flutter_sdk';
-  static const String version = '3.4.1';
+  static const String version = '3.4.2';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: optimizely_flutter_sdk
 description: This repository houses the Flutter SDK for use with Optimizely Feature Experimentation, Optimizely Full Stack (legacy), and Optimizely Rollouts.
-version: 3.4.1
+version: 3.4.2
 homepage: https://github.com/optimizely/optimizely-flutter-sdk
 
 environment:


### PR DESCRIPTION
## Summary
- Prepare for release 3.4.2

## Context
The fix in PR #98 (_ensure FlutterResult and invokeMethod are always called on main thread_) 

## Test plan
- [ ] CI passes (unit tests, Android build, iOS build)
