### PR TITLE
[FSSDK-12346] [EASYJET] Prepare for release 3.4.3-easyjet      

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Optimizely Flutter SDK Changelog
 
+## 3.4.3-easyjet
+April 20, 2026
+
+**Note:** This is a client-specific pre-release version for EasyJet.
+
+### Bug Fixes
+* Upgrade NWPathMonitor iOS requirement to iOS 17.0 to address rare crash on older iOS versions
+* Add fail-safe initialization guards in NetworkReachability to prevent null pointer crashes
+* Use custom swift-sdk branch with defensive NWPathMonitor handling
+
+**Dependencies:**
+* OptimizelySwiftSDK: git branch `fix/upgrade-nwpathmonitor-ios17-requirement`
+
 ## 3.4.2
 March 25, 2026
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Other Flutter platforms are not currently supported by this SDK.
 To add the flutter-sdk to your project dependencies, include the following in your app's pubspec.yaml:
 
 ```
-   optimizely_flutter_sdk: ^3.4.2
+   optimizely_flutter_sdk: ^3.4.3-easyjet
 ```
 
 Then run 

--- a/ios/optimizely_flutter_sdk.podspec
+++ b/ios/optimizely_flutter_sdk.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source              = { :path => '.' }
   s.source_files        = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'OptimizelySwiftSDK', :git => 'https://github.com/optimizely/swift-sdk.git', :branch => 'fix/upgrade-nwpathmonitor-ios17-requirement'
+  s.dependency 'OptimizelySwiftSDK'
   s.platform            = :ios, '10.0'
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/optimizely_flutter_sdk.podspec
+++ b/ios/optimizely_flutter_sdk.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source              = { :path => '.' }
   s.source_files        = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'OptimizelySwiftSDK', '5.2.1'
+  s.dependency 'OptimizelySwiftSDK', :git => 'https://github.com/optimizely/swift-sdk.git', :branch => 'fix/upgrade-nwpathmonitor-ios17-requirement'
   s.platform            = :ios, '10.0'
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/lib/package_info.dart
+++ b/lib/package_info.dart
@@ -3,5 +3,5 @@
 
 class PackageInfo {
   static const String name = 'optimizely_flutter_sdk';
-  static const String version = '3.4.2';
+  static const String version = '3.4.3-easyjet';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: optimizely_flutter_sdk
 description: This repository houses the Flutter SDK for use with Optimizely Feature Experimentation, Optimizely Full Stack (legacy), and Optimizely Rollouts.
-version: 3.4.2
+version: 3.4.3-easyjet
 homepage: https://github.com/optimizely/optimizely-flutter-sdk
 
 environment:


### PR DESCRIPTION
## Summary
EasyJet reported rare crashes on iOS 16 physical devices during
  SDK initialization:                                               
  - **Crash:** `EXC_BAD_ACCESS` at null pointer in
  `NetworkReachability`                                             
  - **Location:** OptimizelySwiftSDK 5.2.1, `NWPathMonitor`
  initialization                                                    
  - **Devices:** iPhone 8, iOS 16.7.14
                                                                    
  ## Solution
  Client-specific pre-release with two fixes:                       
                                                                    
  1. **Swift SDK** (branch                                          
  `fix/upgrade-nwpathmonitor-ios17-requirement`):                   
     - Upgrade NWPathMonitor requirement: iOS 12.0 → iOS 17.0       
     - Replace force casts with safe optional guards                
     - Fail-safe initialization to prevent crashes                  
                                                                    
  2. **Flutter SDK** (this PR):                                     
     - Point podspec to swift-sdk fix branch
     - Version: `3.4.3-easyjet` (pre-release identifier)            
     - Update all version files + CHANGELOG       


## Test plan
- All Test cases should be passed

## Issues
- [FSSDK-12346](https://optimizely-ext.atlassian.net/browse/FSSDK-12346)

[FSSDK-12346]: https://optimizely-ext.atlassian.net/browse/FSSDK-12346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ