### PR TITLE
[FSSDK-12503] fix: guard static MethodChannel from multi-engine overwrite

### DIFF
--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/FlutterLogbackAppender.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/FlutterLogbackAppender.java
@@ -18,9 +18,13 @@ public class FlutterLogbackAppender extends AppenderBase<ILoggingEvent> {
     private static final Handler mainThreadHandler = new Handler(Looper.getMainLooper());
 
     public static void setChannel(MethodChannel newChannel) {
-        if (newChannel == null || FlutterLogbackAppender.channel == null) {
-            FlutterLogbackAppender.channel = newChannel;
+        if (channel == null) {
+            channel = newChannel;
         }
+    }
+
+    public static void clearChannel() {
+        channel = null;
     }
 
     @Override

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/FlutterLogbackAppender.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/FlutterLogbackAppender.java
@@ -17,8 +17,10 @@ public class FlutterLogbackAppender extends AppenderBase<ILoggingEvent> {
     public static MethodChannel channel;
     private static final Handler mainThreadHandler = new Handler(Looper.getMainLooper());
 
-    public static void setChannel(MethodChannel channel) {
-        FlutterLogbackAppender.channel = channel;
+    public static void setChannel(MethodChannel newChannel) {
+        if (newChannel == null || FlutterLogbackAppender.channel == null) {
+            FlutterLogbackAppender.channel = newChannel;
+        }
     }
 
     @Override

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/FlutterLogbackAppender.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/FlutterLogbackAppender.java
@@ -14,7 +14,7 @@ import io.flutter.plugin.common.MethodChannel;
 public class FlutterLogbackAppender extends AppenderBase<ILoggingEvent> {
 
     public static final String CHANNEL_NAME = "optimizely_flutter_sdk_logger";
-    public static MethodChannel channel;
+    private static MethodChannel channel;
     private static final Handler mainThreadHandler = new Handler(Looper.getMainLooper());
 
     public static void setChannel(MethodChannel newChannel) {

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/OptimizelyFlutterSdkPlugin.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/OptimizelyFlutterSdkPlugin.java
@@ -212,6 +212,9 @@ public class OptimizelyFlutterSdkPlugin extends OptimizelyFlutterClient implemen
 
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+    if (channel != null) {
+      return;
+    }
     channel = new MethodChannel(binding.getBinaryMessenger(), "optimizely_flutter_sdk");
     channel.setMethodCallHandler(this);
     context = binding.getApplicationContext();
@@ -232,6 +235,7 @@ public class OptimizelyFlutterSdkPlugin extends OptimizelyFlutterClient implemen
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     channel.setMethodCallHandler(null);
+    channel = null;
     // Stop and detach the appender
     if (flutterLogbackAppender != null) {
         Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);

--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/OptimizelyFlutterSdkPlugin.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/OptimizelyFlutterSdkPlugin.java
@@ -243,8 +243,8 @@ public class OptimizelyFlutterSdkPlugin extends OptimizelyFlutterClient implemen
         flutterLogbackAppender.stop();
         flutterLogbackAppender = null;
     }
-    // Clean up the channel
-    FlutterLogbackAppender.setChannel(null);
+    // Clean up the logger channel
+    FlutterLogbackAppender.clearChannel();
   }
 
   @Override

--- a/ios/Classes/OptimizelyFlutterLogger.swift
+++ b/ios/Classes/OptimizelyFlutterLogger.swift
@@ -12,8 +12,10 @@ public class OptimizelyFlutterLogger: NSObject, OPTLogger {
         super.init()
     }
     
-    public static func setChannel(_ channel: FlutterMethodChannel) {
-        loggerChannel = channel
+    public static func setChannel(_ channel: FlutterMethodChannel?) {
+        if channel == nil || loggerChannel == nil {
+            loggerChannel = channel
+        }
     }
     
     public func log(level: OptimizelyLogLevel, message: String) {

--- a/ios/Classes/OptimizelyFlutterLogger.swift
+++ b/ios/Classes/OptimizelyFlutterLogger.swift
@@ -12,10 +12,14 @@ public class OptimizelyFlutterLogger: NSObject, OPTLogger {
         super.init()
     }
     
-    public static func setChannel(_ channel: FlutterMethodChannel?) {
-        if channel == nil || loggerChannel == nil {
+    public static func setChannel(_ channel: FlutterMethodChannel) {
+        if loggerChannel == nil {
             loggerChannel = channel
         }
+    }
+
+    public static func clearChannel() {
+        loggerChannel = nil
     }
     
     public func log(level: OptimizelyLogLevel, message: String) {

--- a/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
@@ -38,6 +38,9 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
     
     /// Registers optimizely_flutter_sdk channel to communicate with the flutter sdk to receive requests and send responses
     public static func register(with registrar: FlutterPluginRegistrar) {
+        if channel != nil {
+            return
+        }
         channel = FlutterMethodChannel(name: "optimizely_flutter_sdk", binaryMessenger: registrar.messenger())
         let instance = SwiftOptimizelyFlutterSdkPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)

--- a/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
@@ -53,7 +53,13 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
                                                 taskQueue: taskQueue)
         OptimizelyFlutterLogger.setChannel(loggerChannel)
     }
-    
+
+    public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+        Self.channel?.setMethodCallHandler(nil)
+        Self.channel = nil
+        OptimizelyFlutterLogger.clearChannel()
+    }
+
     /// Part of FlutterPlugin protocol to handle communication with flutter sdk.
     /// All method handlers receive a main-thread-safe result callback so that
     /// any handler calling result() from a background thread (e.g. async SDK


### PR DESCRIPTION
## Summary
- Fix notification listeners silently breaking when `onAttachedToEngine` (Android) / `register(with:)` (iOS) is called more than once
- Root cause: static `MethodChannel` was unconditionally overwritten by a second Flutter engine (e.g. Firebase background messaging), causing notification callbacks to route to the wrong engine
- Fix: guard the channel assignment with a null check; null the channel in `onDetachedFromEngine` for proper lifecycle

## Changes
- **Android `OptimizelyFlutterSdkPlugin.java`**: Early return in `onAttachedToEngine` if channel already set; set `channel = null` in `onDetachedFromEngine`
- **Android `FlutterLogbackAppender.java`**: Guard `setChannel()` from overwriting active channel
- **iOS `SwiftOptimizelyFlutterSdkPlugin.swift`**: Early return in `register(with:)` if channel already set
- **iOS `OptimizelyFlutterLogger.swift`**: Guard `setChannel()` from overwriting active channel

## Test plan
- [x] Run existing Dart unit tests (`flutter test`) - 140/140 passed, no regressions
- [x] Run `flutter analyze` - no issues found
- [ ] Run multi-engine integration test on Android emulator (see [flutter-testapp PR](https://github.com/optimizely/optimizely-flutter-testapp/pulls))
- [ ] Verify decision notification listener fires after second engine creation
- [ ] Verify track notification listener fires after second engine creation
- [ ] Verify SDK still works normally in single-engine scenario

Fixes FSSDK-12503

🤖 Generated with [Claude Code](https://claude.ai/code)