### PR TITLE
[FSSDK-12503] fix: guard detachFromEngine from multi-engine channel teardown

### DIFF
--- a/android/src/main/java/com/optimizely/optimizely_flutter_sdk/OptimizelyFlutterSdkPlugin.java
+++ b/android/src/main/java/com/optimizely/optimizely_flutter_sdk/OptimizelyFlutterSdkPlugin.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -47,6 +48,7 @@ import ch.qos.logback.core.Appender;
 public class OptimizelyFlutterSdkPlugin extends OptimizelyFlutterClient implements FlutterPlugin, ActivityAware, MethodCallHandler {
 
   public static MethodChannel channel;
+  private static BinaryMessenger attachedMessenger;
   private Appender<ILoggingEvent> flutterLogbackAppender;
 
   /**
@@ -215,7 +217,8 @@ public class OptimizelyFlutterSdkPlugin extends OptimizelyFlutterClient implemen
     if (channel != null) {
       return;
     }
-    channel = new MethodChannel(binding.getBinaryMessenger(), "optimizely_flutter_sdk");
+    attachedMessenger = binding.getBinaryMessenger();
+    channel = new MethodChannel(attachedMessenger, "optimizely_flutter_sdk");
     channel.setMethodCallHandler(this);
     context = binding.getApplicationContext();
 
@@ -234,8 +237,12 @@ public class OptimizelyFlutterSdkPlugin extends OptimizelyFlutterClient implemen
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    if (binding.getBinaryMessenger() != attachedMessenger) {
+      return;
+    }
     channel.setMethodCallHandler(null);
     channel = null;
+    attachedMessenger = null;
     // Stop and detach the appender
     if (flutterLogbackAppender != null) {
         Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);

--- a/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
@@ -30,7 +30,8 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
     
     // to communicate with optimizely flutter sdk
     static var channel: FlutterMethodChannel!
-    
+    private static weak var attachedMessenger: FlutterBinaryMessenger?
+
     // to track each unique userContext
     var uuid: String {
         return UUID().uuidString
@@ -41,7 +42,9 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
         if channel != nil {
             return
         }
-        channel = FlutterMethodChannel(name: "optimizely_flutter_sdk", binaryMessenger: registrar.messenger())
+        let messenger = registrar.messenger()
+        attachedMessenger = messenger
+        channel = FlutterMethodChannel(name: "optimizely_flutter_sdk", binaryMessenger: messenger)
         let instance = SwiftOptimizelyFlutterSdkPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)
 
@@ -55,8 +58,12 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
     }
 
     public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+        guard registrar.messenger() === Self.attachedMessenger else {
+            return
+        }
         Self.channel?.setMethodCallHandler(nil)
         Self.channel = nil
+        Self.attachedMessenger = nil
         OptimizelyFlutterLogger.clearChannel()
     }
 


### PR DESCRIPTION
## Summary

- **Android**: `onDetachedFromEngine` now checks if the detaching engine's `BinaryMessenger` matches the one that created the channel — skips cleanup if it doesn't match
- **iOS**: `detachFromEngine` now compares `registrar.messenger()` against the stored `attachedMessenger` — skips cleanup if they differ
- Fixes the case where a secondary Flutter engine (e.g. Firebase background messaging) detaching would destroy the primary engine's MethodChannel, breaking all SDK calls and notification callbacks

## Context

The `onAttachedToEngine`/`register` fix from #103 correctly guards against channel overwrite on attach (`if channel != null { return }`). But `onDetachedFromEngine`/`detachFromEngine` unconditionally nils the channel — so when the secondary engine detaches, it destroys the primary engine's channel.

## Test plan

- [ ] Run multi-engine notification listener integration test on Android emulator
- [ ] Run multi-engine notification listener integration test on iOS simulator
- [ ] Verify decision listener fires after second engine is created
- [ ] Verify track listener fires after second engine is created
- [ ] Verify decision listener works after second engine is destroyed (new test case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)