### PR TITLE
[FSSDK-12512] feat: add feature rollout support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.7'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.1.0"
-    implementation "com.optimizely.ab:android-sdk:5.1.1"
+    implementation "com.optimizely.ab:android-sdk:5.2.0"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
     implementation ('com.google.guava:guava:19.0') {
         exclude group:'com.google.guava', module:'listenablefuture'

--- a/ios/optimizely_flutter_sdk.podspec
+++ b/ios/optimizely_flutter_sdk.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source              = { :path => '.' }
   s.source_files        = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'OptimizelySwiftSDK', '5.2.1'
+  s.dependency 'OptimizelySwiftSDK', '5.3.0'
   s.platform            = :ios, '10.0'
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## Summary
- Bumps iOS `OptimizelySwiftSDK` from `5.2.1` → `5.3.0`
- Bumps Android `android-sdk` from `5.1.1` → `5.2.0`

This brings in **feature rollout** support from the native SDKs. Feature rollout (`type: "fr"`) is a new experiment type that combines targeted delivery simplicity with A/B test measurement capabilities. The implementation is handled internally by the native SDKs (datafile processing) — no Flutter-layer API changes are needed.

## Test plan
- [x] `flutter analyze` — no issues found
- [x] `flutter test` — all 140 tests pass
- [ ] CI: unit_test_coverage (macOS)
- [ ] CI: build_test_android (Ubuntu)
- [ ] CI: build_test_ios (macOS)
- [x] Perform bug bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)